### PR TITLE
Blow away the contents of the S3 bucket and re-copy them on each deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
 
 deploy:
   provider: 'script'
-  script: 's3cmd sync --verbose --delete-removed ./public/ s3://disjoint.ca/'
+  script: 'scripts/s3deploy.sh'
   skip_cleanup: true
   on:
     branch: 'master'

--- a/scripts/s3deploy.sh
+++ b/scripts/s3deploy.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+s3cmd del --recursive --force s3://disjoint.ca
+s3cmd sync --verbose --delete-removed ./public/ s3://disjoint.ca/


### PR DESCRIPTION
Considering the tiny size of the contents, it's not really worth optimizing here.
