### PR TITLE
Invalidate root URLs, vs specifying individual paths

### DIFF
--- a/s3_website.yml
+++ b/s3_website.yml
@@ -6,5 +6,6 @@ site: "public"
 max_age: 300
 
 cloudfront_distribution_id: "<%= ENV['CLOUDFRONT_DISTRIBUTION_ID'] %>"
+cloudfront_invalidate_root: true
 
 concurrency_level: 5


### PR DESCRIPTION
Without this, we end up in a weird state where an individual file has been invalidated, but the root path still returns the old content (since content is being served from an S3 bucket)
