### PR TITLE
Stick to using only tags for all posts

### DIFF
--- a/archetypes/post.md
+++ b/archetypes/post.md
@@ -1,7 +1,4 @@
 ---
-categories:
-  - "category1"
-  - "category2"
 tags:
   - "tag1"
   - "tag2"

--- a/config.yaml
+++ b/config.yaml
@@ -16,7 +16,6 @@ permalinks:
   post: "/posts/:year/:month/:day/:title/"
 
 taxonomies:
-  category: "categories"
   tag: "tags"
 
 #

--- a/layouts/_default/frontpage-post.html
+++ b/layouts/_default/frontpage-post.html
@@ -1,0 +1,76 @@
+	{{ if eq .Type "post" }}
+		{{ if ne .Params.menu "main" }}
+			<div class="row">
+				<!-- <div class="col-md-offset-1 col-md-10"> -->
+				<div class="col-md-offset-1 col-md-10">
+					<h3><a href="{{.Permalink}}">{{ .Title }}</a></h3>
+						<small><span class="label label-primary">
+							{{ if .Site.Params.strings.date_format }}
+								{{ .Date.Format .Site.Params.strings.date_format }}
+							{{ else }}
+								{{ .Date.Format "Mon, Jan 2, 2006" }}
+							{{ end }}</span>&nbsp;using tags
+							{{ range $i, $e :=.Params.tags }}
+								{{if $i}} , {{end}}
+							<a href="/tags/{{ . | urlize }}">{{ . }}</a>
+						{{ end }}
+					</small>
+				</div>
+			</div>
+			<div class="row">
+				<div class="col-md-offset-1 col-md-10">
+					<br>
+					{{ if .Site.Params.use_summaries }}
+	  					{{ if .Params.nocut }}
+		  					{{ .Content }}
+			  			{{ else }}
+	  		  				{{ .Summary }}
+					  		<br>
+						  	<a href="{{ .Permalink }}">
+						  	{{ if .Site.Params.strings.read_more_link }}
+						  		{{ .Site.Params.strings.read_more_link }}
+						  	{{ else }}
+						  		Read more
+						  	{{ end }}</a>
+					  	{{ end }}
+					{{ else }}
+						{{ .Content }}
+					{{ end }}
+				</div>
+			</div>
+			<div class="row">
+				<div class="col-md-12">
+					<hr>
+				</div>
+			</div>
+		{{ end }}
+	{{ else if eq .Type "link" }}
+		<div class="row">
+			<div class="col-md-offset-1 col-md-10">
+				<small>
+					<span class="label label-primary">
+						{{ if .Site.Params.strings.date_format }}
+							{{ .Date.Format .Site.Params.strings.date_format }}
+						{{ else }}
+							{{ .Date.Format "Mon, Jan 2, 2006" }}
+						{{ end }}
+					</span>
+					&nbsp;<b>
+						{{ if .Site.Params.strings.linklog_text }}
+							{{ .Site.Params.strings.linklog_text }}
+						{{ else }}
+							Linklog:
+						{{ end }}
+					</b>&nbsp;{{ .Params.author }}: <a href="{{ .Permalink }}">{{ .Title }}</a>
+				</small>
+				<small>
+					{{ .Content }}
+				</small>
+				</div>
+				<div class="row">
+					<div class="col-md-12">
+						<hr>
+					</div>
+				</div>
+		</div>
+	{{ end }}

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -1,0 +1,28 @@
+{{ partial "header.html" . }}
+
+<div class="container">
+	<div class="row">
+		<div class="col-md-offset-1 col-md-10">
+			<h3>{{ .Title }}</h3>
+				<span class="label label-primary">{{ if .Site.Params.strings.date_format }}{{ .Date.Format .Site.Params.strings.date_format }}{{ else }}{{ .Date.Format "Mon, Jan 2, 2006" }}{{ end }}</span> using tags
+				{{ range $i, $e :=.Params.tags }}
+					{{if $i}} , {{end}}
+					<a href="/tags/{{ . | urlize }}">{{ . }}</a>
+				{{ end }}
+			</small>
+		</div>
+	</div>
+	<div class="row">
+		<div class="col-md-offset-1 col-md-10">
+			<br>
+			{{ .Content }}
+		</div>
+	</div>
+	<div class="row">
+		<div class="col-md-12">
+			<hr>
+		</div>
+	</div>
+</div>
+
+{{ partial "footer.html" . }}


### PR DESCRIPTION
Categories seemed a bit too much for my needs so decided to do away with it.

Note that `frontpage-post.html` and `single.html` were both copied from the `hugo-multi-bootswatch` theme and overridden here (as per Hugo guidelines)
