### PR TITLE
Import the Google font over https instead of http

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,4 +1,4 @@
-@import url('http://fonts.googleapis.com/css?family=Ubuntu:bold');
+@import url('https://fonts.googleapis.com/css?family=Ubuntu:bold');
 
 .image-floatleft
 {


### PR DESCRIPTION
Browsers get super mad when you try and pull this off on an https site.
