### PR TITLE
Install git-lfs as part of the pre-build step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ jdk:
 cache:
   directories:
     - 'node_modules'
+    - '$HOME/bin'
 
 env:
   global:
@@ -22,6 +23,11 @@ env:
     - 'GOOGLE_ADSENSE_SLOT_ID=1182212332'
 
 before_install:
+  - 'mkdir -p $HOME/bin'
+  - 'mkdir -p $HOME/tmp'
+  - '[ -f $HOME/bin/git-lfs ] || (wget -O $HOME/tmp/git-lfs.tar.gz https://github.com/github/git-lfs/releases/download/v1.5.3/git-lfs-linux-amd64-1.5.3.tar.gz && tar xfz $HOME/tmp/git-lfs.tar.gz -C $HOME/tmp/ && mv $HOME/tmp/git-lfs-1.5.3/git-lfs $HOME/bin/git-lfs)'
+  - 'chmod +x $HOME/bin/git-lfs'
+  - 'export PATH=$PATH:$HOME/bin/'
   - 'git lfs install'
   - 'git lfs pull'
   - 'rvm use 2.3'


### PR DESCRIPTION
The version of git lfs currently installed on the Trusty containers (0.5.0) is really old and I cannot seem to get that version to do what I need.